### PR TITLE
Add QR code download button

### DIFF
--- a/components/dashboard/links/QRCode.vue
+++ b/components/dashboard/links/QRCode.vue
@@ -1,4 +1,6 @@
 <script setup>
+import { Button } from '#components'
+import { Download } from 'lucide-vue-next'
 import QRCodeStyling from 'qr-code-styling'
 
 const props = defineProps({
@@ -68,14 +70,27 @@ const options = {
 const qrCode = new QRCodeStyling(options)
 const qrCodeEl = ref(null)
 
+function downloadQRCode() {
+  qrCode.download({
+    extension: 'png',
+    name: `qr-${props.data}`,
+  })
+}
+
 onMounted(() => {
   qrCode.append(qrCodeEl.value)
 })
 </script>
 
 <template>
-  <div
-    ref="qrCodeEl"
-    :data-text="data"
-  />
+  <div class="flex flex-col items-center gap-4">
+    <div
+      ref="qrCodeEl"
+      :data-text="data"
+    />
+    <Button variant="outline" @click="downloadQRCode">
+      <Download class="w-4 h-4 mr-2" />
+      Download QR Code
+    </Button>
+  </div>
 </template>

--- a/components/dashboard/links/QRCode.vue
+++ b/components/dashboard/links/QRCode.vue
@@ -71,9 +71,10 @@ const qrCode = new QRCodeStyling(options)
 const qrCodeEl = ref(null)
 
 function downloadQRCode() {
+  const slug = props.data.split('/').pop()
   qrCode.download({
     extension: 'png',
-    name: `qr-${props.data}`,
+    name: `qr_${slug}`,
   })
 }
 


### PR DESCRIPTION
This PR adds a download functionality to the QR code component:

- Adds a "Download QR Code" button below the QR code
- Uses qr-code-styling's built-in download method
- Generates clean filenames like "qr_slug.png"

UI Changes:
- Adds Button component with Download icon
- Centers QR code and button with proper spacing
- Uses outline variant for button styling

Technical Changes:
- Imports Button from UI components
- Imports Download icon from lucide-vue-next
- Adds downloadQRCode function to handle file saving
- Extracts slug from URL for cleaner filenames